### PR TITLE
Make default task build

### DIFF
--- a/generators/app/templates/Gruntfile.js
+++ b/generators/app/templates/Gruntfile.js
@@ -217,7 +217,7 @@ module.exports = function (grunt) {
     grunt.registerTask(
         "default",
         "Watches for changes and automatically creates an MPK file, as well as copying the changes to your deployment folder",
-        [ "watch" ]
+        [ "clean build", "watch" ]
     );
 
     grunt.registerTask(


### PR DESCRIPTION
Default task should clean build and watch after so  you can run `> grunt`