### PR TITLE
update to gulp 4

### DIFF
--- a/generators/app/templates/Gulpfile.js
+++ b/generators/app/templates/Gulpfile.js
@@ -13,7 +13,8 @@ var gulp = require("gulp"),
     zip = require("gulp-zip"),
     del = require("del"),
     newer = require("gulp-newer"),
-    gutil = require("gulp-util"),
+    log = require('fancy-log'),
+    colors = require('ansi-colors'), 
     plumber = require("gulp-plumber"),
     gulpif = require("gulp-if"),
     jsonTransform = require("gulp-json-transform"),
@@ -49,12 +50,12 @@ gulp.task("compress", ["clean"], function () {
 gulp.task("copy:js", function () {
     return gulp.src(["./src/**/*.js"])
         .pipe(plumber(function (error) {
-            var msg = gutil.colors.red("Error");
+            var msg = colors.red("Error");
             if (error.fileName) {
-                msg += gutil.colors.red(" in ") + gutil.colors.cyan(error.fileName);
+                msg += colors.red(" in ") + colors.cyan(error.fileName);
             }
-            msg += " : " + gutil.colors.cyan(error.message);
-            gutil.log(msg);
+            msg += " : " + colors.cyan(error.message);
+            log(msg);
             this.emit("end");
         }))
         .pipe(jsValidate())
@@ -85,10 +86,10 @@ gulp.task("version:json", function () {
 
 gulp.task("icon", function (cb) {
     var icon = (typeof argv.file !== "undefined") ? argv.file : "./icon.png";
-    console.log("\nUsing this file to create a base64 string: " + gutil.colors.cyan(icon));
+    console.log("\nUsing this file to create a base64 string: " + colors.cyan(icon));
     gulp.src(icon)
         .pipe(intercept(function (file) {
-            console.log("\nCopy the following to your " + pkg.name + ".xml (after description):\n\n" + gutil.colors.cyan("<icon>") + file.contents.toString("base64") + gutil.colors.cyan("<\/icon>") + "\n");
+            console.log("\nCopy the following to your " + pkg.name + ".xml (after description):\n\n" + colors.cyan("<icon>") + file.contents.toString("base64") + colors.cyan("<\/icon>") + "\n");
             cb();
         }));
 });

--- a/generators/app/templates/Gulpfile.js
+++ b/generators/app/templates/Gulpfile.js
@@ -27,80 +27,89 @@ var pkg = require("./package.json"),
     paths = widgetBuilderHelper.generatePaths(pkg),
     xmlversion = widgetBuilderHelper.xmlversion;
 
-gulp.task("default", ['build'], function() {
-    gulp.watch("./src/**/*", ["compress"]);
-    gulp.watch("./src/**/*.js", ["copy:js"]);
-    gulp.watch("./src/**/*.html", ["copy:html"])
-});
-
-gulp.task("clean", function () {
-    return del([
-        paths.WIDGET_TEST_DEST,
-        paths.WIDGET_DIST_DEST
-    ], { force: true });
-});
-
-gulp.task("compress", ["clean"], function () {
-    return gulp.src("src/**/*")
-        .pipe(zip(pkg.name + ".mpk"))
-        .pipe(gulp.dest(paths.TEST_WIDGETS_FOLDER))
-        .pipe(gulp.dest("dist"));
-});
-
-gulp.task("copy:js", function () {
-    return gulp.src(["./src/**/*.js"])
-        .pipe(plumber(function (error) {
-            var msg = colors.red("Error");
-            if (error.fileName) {
-                msg += colors.red(" in ") + colors.cyan(error.fileName);
-            }
-            msg += " : " + colors.cyan(error.message);
-            log(msg);
-            this.emit("end");
-        }))
-        .pipe(jsValidate())
-        .pipe(newer(paths.TEST_WIDGETS_DEPLOYMENT_FOLDER))
-        .pipe(gulp.dest(paths.TEST_WIDGETS_DEPLOYMENT_FOLDER));
-});
-
-gulp.task("copy:html", function () {
-    return gulp.src(["./src/**/*.html"])
-        .pipe(newer(paths.TEST_WIDGETS_DEPLOYMENT_FOLDER))
-        .pipe(gulp.dest(paths.TEST_WIDGETS_DEPLOYMENT_FOLDER));
-});
-
-gulp.task("version:xml", function () {
-    return gulp.src(paths.PACKAGE_XML)
-        .pipe(xmlversion(argv.n))
-        .pipe(gulp.dest("./src/"));
-});
-
-gulp.task("version:json", function () {
-    return gulp.src("./package.json")
-        .pipe(gulpif(typeof argv.n !== "undefined", jsonTransform(function(data) {
-            data.version = argv.n;
-            return data;
-        }, 2)))
-        .pipe(gulp.dest("./"));
-});
-
-gulp.task("icon", function (cb) {
-    var icon = (typeof argv.file !== "undefined") ? argv.file : "./icon.png";
-    console.log("\nUsing this file to create a base64 string: " + colors.cyan(icon));
-    gulp.src(icon)
-        .pipe(intercept(function (file) {
-            console.log("\nCopy the following to your " + pkg.name + ".xml (after description):\n\n" + colors.cyan("<icon>") + file.contents.toString("base64") + colors.cyan("<\/icon>") + "\n");
-            cb();
-        }));
-});
-
-gulp.task("folders", function () {
-    paths.showPaths(); return;
-});
-
-gulp.task("modeler", function (cb) {
-    widgetBuilderHelper.runmodeler(MODELER_PATH, MODELER_ARGS, paths.TEST_PATH, cb);
-});
-
-gulp.task("build", ["compress"]);
-gulp.task("version", ["version:xml", "version:json"]);
+    gulp.task("clean", function () {
+        return del([
+            paths.WIDGET_TEST_DEST,
+            paths.WIDGET_DIST_DEST
+        ], { force: true });
+    });
+    
+    gulp.task("compress", gulp.series(["clean"], function () {
+        return gulp.src("src/**/*")
+            .pipe(zip(pkg.name + ".mpk"))
+            .pipe(gulp.dest(paths.TEST_WIDGETS_FOLDER))
+            .pipe(gulp.dest("dist"));
+    }));
+    
+    gulp.task("build", gulp.series(["compress"]));
+    
+    gulp.task("default", gulp.series(['build'], function() {
+        gulp.watch("./src/**/*", ["compress"]);
+        gulp.watch("./src/**/*.js", ["copy:js"]);
+        gulp.watch("./src/**/*.html", ["copy:html"])
+    }));
+    
+    gulp.task("compress", gulp.series(["clean"], function () {
+        return gulp.src("src/**/*")
+            .pipe(zip(pkg.name + ".mpk"))
+            .pipe(gulp.dest(paths.TEST_WIDGETS_FOLDER))
+            .pipe(gulp.dest("dist"));
+    }));
+    
+    gulp.task("copy:js", function () {
+        return gulp.src(["./src/**/*.js"])
+            .pipe(plumber(function (error) {
+                var msg = colors.red("Error");
+                if (error.fileName) {
+                    msg += colors.red(" in ") + colors.cyan(error.fileName);
+                }
+                msg += " : " + colors.cyan(error.message);
+                log(msg);
+                this.emit("end");
+            }))
+            .pipe(jsValidate())
+            .pipe(newer(paths.TEST_WIDGETS_DEPLOYMENT_FOLDER))
+            .pipe(gulp.dest(paths.TEST_WIDGETS_DEPLOYMENT_FOLDER));
+    });
+    
+    gulp.task("copy:html", function () {
+        return gulp.src(["./src/**/*.html"])
+            .pipe(newer(paths.TEST_WIDGETS_DEPLOYMENT_FOLDER))
+            .pipe(gulp.dest(paths.TEST_WIDGETS_DEPLOYMENT_FOLDER));
+    });
+    
+    gulp.task("version:xml", function () {
+        return gulp.src(paths.PACKAGE_XML)
+            .pipe(xmlversion(argv.n))
+            .pipe(gulp.dest("./src/"));
+    });
+    
+    gulp.task("version:json", function () {
+        return gulp.src("./package.json")
+            .pipe(gulpif(typeof argv.n !== "undefined", jsonTransform(function(data) {
+                data.version = argv.n;
+                return data;
+            }, 2)))
+            .pipe(gulp.dest("./"));
+    });
+    
+    gulp.task("icon", function (cb) {
+        var icon = (typeof argv.file !== "undefined") ? argv.file : "./icon.png";
+        console.log("\nUsing this file to create a base64 string: " + colors.cyan(icon));
+        gulp.src(icon)
+            .pipe(intercept(function (file) {
+                console.log("\nCopy the following to your " + pkg.name + ".xml (after description):\n\n" + colors.cyan("<icon>") + file.contents.toString("base64") + colors.cyan("<\/icon>") + "\n");
+                cb();
+            }));
+    });
+    
+    gulp.task("folders", function () {
+        paths.showPaths(); return;
+    });
+    
+    gulp.task("modeler", function (cb) {
+        widgetBuilderHelper.runmodeler(MODELER_PATH, MODELER_ARGS, paths.TEST_PATH, cb);
+    });
+    
+    gulp.task("version", gulp.parallel(["version:xml", "version:json"]));
+    

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -24,16 +24,16 @@
     "ansi-colors": "^4.1.1",
     "del": "^2.2.2",
     "fancy-log": "^1.3.3",
-    "gulp": "^3.9.1",
-    "gulp-if": "^2.0.1",
+    "gulp": "^4.0.2",
+    "gulp-if": "^3.0.0",
     "gulp-intercept": "^0.1.0",
-    "gulp-json-transform": "^0.4.2",
-    "gulp-newer": "^1.3.0",
-    "gulp-plumber": "^1.1.0",
-    "gulp-zip": "^3.2.0",
-    "gulp-jsvalidate": "^3.0.0",
+    "gulp-json-transform": "^0.4.7",
+    "gulp-newer": "^1.4.0",
+    "gulp-plumber": "^1.2.1",
+    "gulp-zip": "^5.0.0",
+    "gulp-jsvalidate": "^4.0.0",
     "widgetbuilder-gulp-helper": "https://github.com/tieniber/widgetbuilder-gulp-helper/archive/1.0.2.tar.gz",
-    "yargs": "^6.0.0"
+    "yargs": "^14.0.0"
   },<% } %>
   "engines": {
     "node": ">=5"

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -21,17 +21,18 @@
     "shelljs": "^0.7.4",
     "xml2js": "^0.4.17"
   },<% } if (builder == 'gulp') { %>
+    "ansi-colors": "^4.1.1",
     "del": "^2.2.2",
+    "fancy-log": "^1.3.3",
     "gulp": "^3.9.1",
     "gulp-if": "^2.0.1",
     "gulp-intercept": "^0.1.0",
     "gulp-json-transform": "^0.4.2",
     "gulp-newer": "^1.3.0",
     "gulp-plumber": "^1.1.0",
-    "gulp-util": "^3.0.7",
     "gulp-zip": "^3.2.0",
     "gulp-jsvalidate": "^3.0.0",
-    "widgetbuilder-gulp-helper": "https://github.com/JelteMX/widgetbuilder-gulp-helper/archive/1.0.1.tar.gz",
+    "widgetbuilder-gulp-helper": "https://github.com/tieniber/widgetbuilder-gulp-helper/archive/1.0.2.tar.gz",
     "yargs": "^6.0.0"
   },<% } %>
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "generator-mendixeric",
+  "name": "generator-mendix",
   "version": "2.2.5",
   "description": "Mendix Widget generator",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "generator-mendix",
-  "version": "2.2.4",
+  "name": "generator-mendixeric",
+  "version": "2.2.5",
   "description": "Mendix Widget generator",
   "license": "MIT",
   "main": "app/index.js",


### PR DESCRIPTION
Updates gulp in scaffolder from 3->4 because scaffolding code would not run in node v12+

NOTE: This commit causes the scaffold _package.json to use [my fork of widgetbuilder-gulp-helper](https://github.com/tieniber/widgetbuilder-gulp-helper) as a dependency instead of your version. I also submitted a PR in widgetbuilder-gulp-helper. Once you've accepted it and released v1.0.2, you should update _package.json to use your repo again.