### PR TITLE
fix for .yo-repository directory

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -73,9 +73,12 @@ module.exports = class extends Generator {
         done();
       }
     } else if (!extfs.isEmptySync(this.destinationRoot())) {
-      this.log(banner);
-      this.log(text.DIR_NOT_EMPTY_ERROR);
-      this.FINISHED = true;
+      var dirs = extfs.getDirsSync(this.destinationRoot());
+      if (!(dirs.length == 1 && dirs[0] == '.yo-repository')) {
+        this.log(banner);
+        this.log(text.DIR_NOT_EMPTY_ERROR);
+        this.FINISHED = true;
+      }
       done();
     } else {
       done();


### PR DESCRIPTION
Fixes #38

yo creates a directory .yo-repository which previously caused generator-mendix to be unable to create a new widget